### PR TITLE
[ADD] Mainmap Map Layout 구현

### DIFF
--- a/DakeAndDevileCorps.xcodeproj/project.pbxproj
+++ b/DakeAndDevileCorps.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		79379FE4288588EC0016D1A8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79379FE3288588EC0016D1A8 /* AppDelegate.swift */; };
 		79379FE6288588EC0016D1A8 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79379FE5288588EC0016D1A8 /* SceneDelegate.swift */; };
-		79379FE8288588EC0016D1A8 /* MapHomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79379FE7288588EC0016D1A8 /* MapHomeViewController.swift */; };
+		79379FE8288588EC0016D1A8 /* MainMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79379FE7288588EC0016D1A8 /* MainMapViewController.swift */; };
 		79379FEE288588EC0016D1A8 /* DakeAndDevileCorps.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 79379FEC288588EC0016D1A8 /* DakeAndDevileCorps.xcdatamodeld */; };
 		79379FF0288588ED0016D1A8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 79379FEF288588ED0016D1A8 /* Assets.xcassets */; };
 		79379FF3288588ED0016D1A8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 79379FF1288588ED0016D1A8 /* LaunchScreen.storyboard */; };
@@ -27,7 +27,7 @@
 		79379FE0288588EC0016D1A8 /* DakeAndDevileCorps.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DakeAndDevileCorps.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		79379FE3288588EC0016D1A8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		79379FE5288588EC0016D1A8 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		79379FE7288588EC0016D1A8 /* MapHomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapHomeViewController.swift; sourceTree = "<group>"; };
+		79379FE7288588EC0016D1A8 /* MainMapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMapViewController.swift; sourceTree = "<group>"; };
 		79379FED288588EC0016D1A8 /* DakeAndDevileCorps.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = DakeAndDevileCorps.xcdatamodel; sourceTree = "<group>"; };
 		79379FEF288588ED0016D1A8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		79379FF2288588ED0016D1A8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -172,7 +172,7 @@
 		7937A00F28858BAB0016D1A8 /* VC */ = {
 			isa = PBXGroup;
 			children = (
-				79379FE7288588EC0016D1A8 /* MapHomeViewController.swift */,
+				79379FE7288588EC0016D1A8 /* MainMapViewController.swift */,
 			);
 			path = VC;
 			sourceTree = "<group>";
@@ -284,7 +284,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				79379FE8288588EC0016D1A8 /* MapHomeViewController.swift in Sources */,
+				79379FE8288588EC0016D1A8 /* MainMapViewController.swift in Sources */,
 				79379FE4288588EC0016D1A8 /* AppDelegate.swift in Sources */,
 				7937A01E28859B490016D1A8 /* SearchViewController.swift in Sources */,
 				79379FE6288588EC0016D1A8 /* SceneDelegate.swift in Sources */,

--- a/DakeAndDevileCorps/Global/Resource/Storyboard/MapHome.storyboard
+++ b/DakeAndDevileCorps/Global/Resource/Storyboard/MapHome.storyboard
@@ -16,9 +16,23 @@
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="oTP-D4-ma4">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                            </mapView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="oTP-D4-ma4" secondAttribute="trailing" id="2Yz-1X-eRs"/>
+                            <constraint firstItem="oTP-D4-ma4" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="A7a-mm-2U2"/>
+                            <constraint firstItem="oTP-D4-ma4" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="FCV-SX-cxn"/>
+                            <constraint firstAttribute="bottom" secondItem="oTP-D4-ma4" secondAttribute="bottom" id="nk3-S3-z5Y"/>
+                        </constraints>
                     </view>
+                    <connections>
+                        <outlet property="mapView" destination="oTP-D4-ma4" id="huG-Jy-HpM"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/DakeAndDevileCorps/Global/Resource/Storyboard/MapHome.storyboard
+++ b/DakeAndDevileCorps/Global/Resource/Storyboard/MapHome.storyboard
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Map Home View Controller-->
+        <!--Main Map View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController storyboardIdentifier="MapHomeViewController" id="Y6W-OH-hqX" customClass="MapHomeViewController" customModule="DakeAndDevileCorps" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="MapHomeViewController" id="Y6W-OH-hqX" customClass="MainMapViewController" customModule="DakeAndDevileCorps" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/DakeAndDevileCorps/Screens/MapHome/VC/MainMapViewController.swift
+++ b/DakeAndDevileCorps/Screens/MapHome/VC/MainMapViewController.swift
@@ -7,13 +7,12 @@
 
 import UIKit
 
-class MapHomeViewController: UIViewController {
+class MainMapViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
-    }
 
+    }
 
 }
 

--- a/DakeAndDevileCorps/Screens/MapHome/VC/MainMapViewController.swift
+++ b/DakeAndDevileCorps/Screens/MapHome/VC/MainMapViewController.swift
@@ -5,10 +5,13 @@
 //  Created by Seungyun Kim on 2022/07/18.
 //
 
+import MapKit
 import UIKit
 
 class MainMapViewController: UIViewController {
 
+    @IBOutlet weak var mapView: MKMapView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/DakeAndDevileCorps/Screens/MapHome/VC/MainMapViewController.swift
+++ b/DakeAndDevileCorps/Screens/MapHome/VC/MainMapViewController.swift
@@ -18,4 +18,3 @@ class MainMapViewController: UIViewController {
     }
 
 }
-


### PR DESCRIPTION
## 🟣 관련 이슈

#14 

## 🟣 구현/변경 사항 및 이유
- Home의 개념을 피하기 위해 뷰 컨트롤러의 이름을 MapHomeViewController에서 MainMapViewController로 바꿨습니다.
- 메인맵뷰컨트롤러에 지도뷰를 삽입하고 레이아웃을 지정하였습니다.

## 🟣 PR Point
- safeArea 범위를 벗어난 오토레이아웃의 적절성

## 🟣 참고 사항
- 디자인 시안
<img width="211" alt="스크린샷 2022-07-20 오후 11 06 51" src="https://user-images.githubusercontent.com/20871603/180002823-371fb1ee-eb9b-48d0-8b78-ca7587aa08ce.png">
- 구현 결과
<img width="331" alt="스크린샷 2022-07-20 오후 11 07 13" src="https://user-images.githubusercontent.com/20871603/180002918-b9ef0842-1008-4e67-bea8-8ebea4e07667.png">

