### PR TITLE
[Add] SearchBarView에서 text 변수 제공 및 마이페이지 버튼 삽입

### DIFF
--- a/DakeAndDevileCorps/Screens/MapHome/Component/SearchBarView.swift
+++ b/DakeAndDevileCorps/Screens/MapHome/Component/SearchBarView.swift
@@ -34,6 +34,11 @@ class SearchBarView: UIView {
         }
     }
     
+    var text: String {
+        get { return textField.text ?? "" }
+        set(value) { textField.text = value }
+    }
+    
     weak var delegate: SearchBarDelegate?
     var leftItemMode: LeftItemMode = .imageMode {
         didSet {
@@ -114,8 +119,9 @@ class SearchBarView: UIView {
             containerView.topAnchor.constraint(equalTo: topAnchor),
             containerView.bottomAnchor.constraint(equalTo: bottomAnchor),
             containerView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            containerView.trailingAnchor.constraint(equalTo: trailingAnchor)
+            containerView.trailingAnchor.constraint(equalTo: trailingAnchor),
         ])
+        
         
         containerView.addSubview(textField)
         NSLayoutConstraint.activate([
@@ -125,6 +131,7 @@ class SearchBarView: UIView {
             textField.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8)
         ])
         
+        // TODO: symbolImageView, leftButton의 오토레이아웃 다시 맞추기
         containerView.addSubview(symbolImageView)
         NSLayoutConstraint.activate([
             symbolImageView.topAnchor.constraint(equalTo: topAnchor, constant: 7),

--- a/DakeAndDevileCorps/Screens/MapHome/Component/SearchBarView.swift
+++ b/DakeAndDevileCorps/Screens/MapHome/Component/SearchBarView.swift
@@ -35,12 +35,12 @@ class SearchBarView: UIView {
     }
     
     enum RightItemMode {
-        case myPageButtom
+        case myPageButton
         case none
         
         var myPageButtonHidden: Bool {
             switch self {
-            case .myPageButtom: return false
+            case .myPageButton: return false
             case .none: return true
             }
         }
@@ -63,7 +63,7 @@ class SearchBarView: UIView {
             leftButton.setImage(leftItemImage, for: .normal)
         }
     }
-    var rightItemMode: RightItemMode = .none {
+    var rightItemMode: RightItemMode = .myPageButton {
         didSet {
             setRightItem()
         }
@@ -151,7 +151,7 @@ class SearchBarView: UIView {
         
         
         containerView.addSubview(textField)
-        let textFieldTrailingConstraintContainerView =  textField.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -8)
+        let textFieldTrailingConstraintContainerView = textField.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -8)
         textFieldTrailingConstraintContainerView.priority = .defaultLow
         NSLayoutConstraint.activate([
             textField.topAnchor.constraint(equalTo: containerView.topAnchor),

--- a/DakeAndDevileCorps/Screens/MapHome/Component/SearchBarView.swift
+++ b/DakeAndDevileCorps/Screens/MapHome/Component/SearchBarView.swift
@@ -34,6 +34,18 @@ class SearchBarView: UIView {
         }
     }
     
+    enum RightItemMode {
+        case myPageButtom
+        case none
+        
+        var myPageButtonHidden: Bool {
+            switch self {
+            case .myPageButtom: return false
+            case .none: return true
+            }
+        }
+    }
+    
     var text: String {
         get { return textField.text ?? "" }
         set(value) { textField.text = value }
@@ -42,13 +54,18 @@ class SearchBarView: UIView {
     weak var delegate: SearchBarDelegate?
     var leftItemMode: LeftItemMode = .imageMode {
         didSet {
-            setComponentsIsHidden()
+            setLeftItemIsHidden()
         }
     }
     var leftItemImage: UIImage = UIImage(systemName: "magnifyingglass") ?? UIImage() {
         didSet {
             symbolImageView.image = leftItemImage
             leftButton.setImage(leftItemImage, for: .normal)
+        }
+    }
+    var rightItemMode: RightItemMode = .none {
+        didSet {
+            setRightItem()
         }
     }
     
@@ -69,6 +86,16 @@ class SearchBarView: UIView {
         button.sizeToFit()
         button.isHidden = leftItemMode.buttonHidden
         button.tintColor = .black
+        return button
+    }()
+    
+    private lazy var myPageButton: UIButton = {
+       let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setBackgroundImage(UIImage(systemName: "person.crop.circle"), for: .normal)
+        button.sizeToFit()
+        button.isHidden = rightItemMode.myPageButtonHidden
+        button.tintColor = .systemGray4
         return button
     }()
     
@@ -124,20 +151,21 @@ class SearchBarView: UIView {
         
         
         containerView.addSubview(textField)
+        let textFieldTrailingConstraintContainerView =  textField.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -8)
+        textFieldTrailingConstraintContainerView.priority = .defaultLow
         NSLayoutConstraint.activate([
-            textField.topAnchor.constraint(equalTo: topAnchor),
-            textField.bottomAnchor.constraint(equalTo: bottomAnchor),
-            
-            textField.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8)
+            textField.topAnchor.constraint(equalTo: containerView.topAnchor),
+            textField.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+            textFieldTrailingConstraintContainerView
         ])
         
         // TODO: symbolImageView, leftButton의 오토레이아웃 다시 맞추기
         containerView.addSubview(symbolImageView)
         NSLayoutConstraint.activate([
-            symbolImageView.topAnchor.constraint(equalTo: topAnchor, constant: 7),
-            symbolImageView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -7),
+            symbolImageView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 7),
+            symbolImageView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -7),
             
-            symbolImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            symbolImageView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
             symbolImageView.trailingAnchor.constraint(equalTo: textField.leadingAnchor, constant: -8),
             
             symbolImageView.widthAnchor.constraint(equalToConstant: 16)
@@ -146,19 +174,35 @@ class SearchBarView: UIView {
         
         containerView.addSubview(leftButton)
         NSLayoutConstraint.activate([
-            leftButton.topAnchor.constraint(equalTo: topAnchor, constant: 7),
-            leftButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -7),
+            leftButton.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 7),
+            leftButton.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -7),
             
-            leftButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            leftButton.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
             symbolImageView.trailingAnchor.constraint(equalTo: textField.leadingAnchor, constant: -11)
+        ])
+        
+        containerView.addSubview(myPageButton)
+        let myPageButtonTrailingConstraintContainerView = myPageButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -8)
+        myPageButtonTrailingConstraintContainerView.priority = .defaultHigh
+
+        NSLayoutConstraint.activate([
+            myPageButton.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 7),
+            myPageButton.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -7),
+            
+            myPageButton.leadingAnchor.constraint(equalTo: textField.trailingAnchor, constant: 8),
+            myPageButtonTrailingConstraintContainerView
         ])
 
     }
     
     // MARK: - set components
-    private func setComponentsIsHidden() {
+    private func setLeftItemIsHidden() {
         leftButton.isHidden = leftItemMode.buttonHidden
         symbolImageView.isHidden = leftItemMode.imageHidden
+    }
+
+    private func setRightItem() {
+        myPageButton.isHidden = rightItemMode.myPageButtonHidden
     }
     
     // MARK: - set TextField


### PR DESCRIPTION
## 🟣 관련 이슈
#35 

## 🟣 구현/변경 사항 및 이유
- SearcBarView의 textField의 text 값에 접근할 수 있도록 했습니다.
- SearchBarView에 마이페이지 버튼을 추가했습니다.

서치바 뷰의 텍스트 인터페이스를 다른 개발자분(닉)께 빠르게 제공해야 해서, 디테일한 부분은 다음 PR에서 추가 반영하겠습니다.
다음 PR에서 적용할 부분
- 서치바 뷰의 왼쪽 버튼과 오른쪽의 마이페이지 버튼의 사진이 찌그러지는 현상
- 마이페이지 버튼의 액션 등록

## 🟣 PR Point
- SearchBarView가 제공하는 text getter/setter의 적절성

## 🟣 참고 사항
<img width="412" alt="스크린샷 2022-07-26 오후 4 18 54" src="https://user-images.githubusercontent.com/20871603/180946992-23bd8307-491a-414d-abb4-bdd97dbfaf41.png">

