### PR TITLE
[FIX] 서치바뷰를 통한 VC 전환 방식을 풀스크린으로 수정

### DIFF
--- a/DakeAndDevileCorps/Screens/MapHome/VC/MainMapViewController.swift
+++ b/DakeAndDevileCorps/Screens/MapHome/VC/MainMapViewController.swift
@@ -46,6 +46,8 @@ extension MainMapViewController: SearchBarDelegate {
         view.endEditing(true)
         
         let nextViewController = UIStoryboard(name: "Search", bundle: nil).instantiateViewController(withIdentifier: SearchViewController.className)
+        nextViewController.modalPresentationStyle = .fullScreen
+        nextViewController.modalTransitionStyle = .crossDissolve
         present(nextViewController, animated: true)
     }
 }


### PR DESCRIPTION
## 🟣 관련 이슈
#35 
## 🟣 구현/변경 사항 및 이유
서치바를 통한 MainMapVC -> SearchVC 로의 전환이 fullScreen + crossDissolve 로 변경

## 🟣 PR Point
- 모달 present 방식의 적절성

## 🟣 참고 사항
<img width="393" alt="스크린샷 2022-07-28 오후 2 47 23" src="https://user-images.githubusercontent.com/20871603/181429934-12f95728-414c-4cda-b6e2-e3aa2f42cb75.png">

