### PR TITLE
[FEAT] TextView Custom 구현

### DIFF
--- a/DakeAndDevileCorps.xcodeproj/project.pbxproj
+++ b/DakeAndDevileCorps.xcodeproj/project.pbxproj
@@ -666,7 +666,7 @@
 				INFOPLIST_FILE = DakeAndDevileCorps/Global/Supports/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = MapHome;
+				INFOPLIST_KEY_UIMainStoryboardFile = StoreDetail;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -697,7 +697,7 @@
 				INFOPLIST_FILE = DakeAndDevileCorps/Global/Supports/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = MapHome;
+				INFOPLIST_KEY_UIMainStoryboardFile = StoreDetail;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/DakeAndDevileCorps.xcodeproj/project.pbxproj
+++ b/DakeAndDevileCorps.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		797CAC542886CFCB0041C3F7 /* RecentSearchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797CAC532886CFCB0041C3F7 /* RecentSearchTableViewCell.swift */; };
 		79D7BA682886EBE100F65ECD /* StoreModelTestN.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D7BA672886EBE100F65ECD /* StoreModelTestN.swift */; };
 		79E2DCA82886E3C800355E30 /* ResultTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79E2DCA72886E3C800355E30 /* ResultTableViewCell.swift */; };
+		B542BE7A2893C64F00F2BC82 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B542BE792893C64F00F2BC82 /* UIViewController+Extension.swift */; };
 		B5B05D4E288F73FD0013E65F /* UIView+Constraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B05D4D288F73FD0013E65F /* UIView+Constraint.swift */; };
 		B5B05D50288F81510013E65F /* ReviewPhotoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B05D4F288F81510013E65F /* ReviewPhotoViewController.swift */; };
 		B5B05D522890ABA10013E65F /* ReviewPhotoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B05D512890ABA10013E65F /* ReviewPhotoCollectionViewCell.swift */; };
@@ -81,6 +82,7 @@
 		797CAC532886CFCB0041C3F7 /* RecentSearchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchTableViewCell.swift; sourceTree = "<group>"; };
 		79D7BA672886EBE100F65ECD /* StoreModelTestN.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreModelTestN.swift; sourceTree = "<group>"; };
 		79E2DCA72886E3C800355E30 /* ResultTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultTableViewCell.swift; sourceTree = "<group>"; };
+		B542BE792893C64F00F2BC82 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		B5B05D4D288F73FD0013E65F /* UIView+Constraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Constraint.swift"; sourceTree = "<group>"; };
 		B5B05D4F288F81510013E65F /* ReviewPhotoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewPhotoViewController.swift; sourceTree = "<group>"; };
 		B5B05D512890ABA10013E65F /* ReviewPhotoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewPhotoCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 				7937A015288597A60016D1A8 /* UIColor+Extension.swift */,
 				B5F1F24A2888313F0021B026 /* UIView+Extension.swift */,
 				B5F1F25228883EC40021B026 /* NSObject+Extension.swift */,
+				B542BE792893C64F00F2BC82 /* UIViewController+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -486,6 +489,7 @@
 				4A6535D828910D53006B6971 /* ProductTableViewCellModel.swift in Sources */,
 				7937A01E28859B490016D1A8 /* SearchViewController.swift in Sources */,
 				4AB368E72886DBD20075E03A /* ItemTableViewCell.swift in Sources */,
+				B542BE7A2893C64F00F2BC82 /* UIViewController+Extension.swift in Sources */,
 				4AB368EC2886F4870075E03A /* ProductTableViewCell.swift in Sources */,
 				B5F3E7E32887DC49000C3129 /* KeywordManager.swift in Sources */,
 				B5F3E7E02887DBA2000C3129 /* Keywords+CoreDataProperties.swift in Sources */,

--- a/DakeAndDevileCorps/Global/Extension/UIViewController+Extension.swift
+++ b/DakeAndDevileCorps/Global/Extension/UIViewController+Extension.swift
@@ -18,4 +18,3 @@ extension UIViewController {
         view.endEditing(true)
     }
 }
-

--- a/DakeAndDevileCorps/Global/Extension/UIViewController+Extension.swift
+++ b/DakeAndDevileCorps/Global/Extension/UIViewController+Extension.swift
@@ -1,0 +1,21 @@
+//
+//  UIViewController+Extension.swift
+//  DakeAndDevileCorps
+//
+//  Created by SHIN YOON AH on 2022/07/29.
+//
+
+import UIKit
+
+extension UIViewController {
+    func hidekeyboardWhenTappedAround() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+    
+    @objc func dismissKeyboard() {
+        view.endEditing(true)
+    }
+}
+

--- a/DakeAndDevileCorps/Global/Resource/Storyboard/StoreDetail.storyboard
+++ b/DakeAndDevileCorps/Global/Resource/Storyboard/StoreDetail.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="L0l-V7-YAj">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>

--- a/DakeAndDevileCorps/Global/Supports/Info.plist
+++ b/DakeAndDevileCorps/Global/Supports/Info.plist
@@ -16,7 +16,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>MapHome</string>
+					<string>StoreDetail</string>
 				</dict>
 			</array>
 		</dict>

--- a/DakeAndDevileCorps/Screens/Store/Component/ReviewTextView.swift
+++ b/DakeAndDevileCorps/Screens/Store/Component/ReviewTextView.swift
@@ -64,7 +64,7 @@ final class ReviewTextView: UIView {
         }
     }
     private let maxCount = 300
-
+    
     // MARK: - init
     
     override init(frame: CGRect) {
@@ -109,12 +109,23 @@ final class ReviewTextView: UIView {
     
     private func setCounter(count: Int) {
         counterLabel.text = "\(count)/\(maxCount)"
-        checkMaxLength(textView: reviewTextView, maxLength: maxCount)
     }
     
     private func checkMaxLength(textView: UITextView, maxLength: Int) {
-        if (textView.text?.count ?? 0 > maxLength) {
-            textView.deleteBackward()
+        guard var textViewText = textView.text else { return }
+        let isOverMaxLength = textViewText.count > maxLength
+        
+        if isOverMaxLength {
+            textViewText.removeLast()
+            textView.text = textViewText + " "
+            rearrangeTextViewText(with: textView, text: textViewText)
+        }
+    }
+    
+    private func rearrangeTextViewText(with textView: UITextView, text: String) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+            textView.text = text
+            self.setCounter(count: textView.text.count)
         }
     }
 }
@@ -134,5 +145,6 @@ extension ReviewTextView: UITextViewDelegate {
     
     func textViewDidChange(_ textView: UITextView) {
         setCounter(count: textView.text?.count ?? 0)
+        checkMaxLength(textView: textView, maxLength: maxCount)
     }
 }

--- a/DakeAndDevileCorps/Screens/Store/Component/ReviewTextView.swift
+++ b/DakeAndDevileCorps/Screens/Store/Component/ReviewTextView.swift
@@ -98,7 +98,7 @@ final class ReviewTextView: UIView {
     }
     
     private func configUI() {
-        counterLabel.text = "0/\(maxCount)"
+        setCounter(count: 0)
         textMode = .beforeWriting
     }
     

--- a/DakeAndDevileCorps/Screens/Store/Component/ReviewTextView.swift
+++ b/DakeAndDevileCorps/Screens/Store/Component/ReviewTextView.swift
@@ -53,6 +53,9 @@ final class ReviewTextView: UIView {
         let textView = UITextView()
         textView.font = .preferredFont(forTextStyle: .subheadline)
         textView.delegate = self
+        textView.autocapitalizationType = .none
+        textView.autocorrectionType = .no
+        textView.spellCheckingType = .no
         return textView
     }()
     private var textMode: TextMode? {

--- a/DakeAndDevileCorps/Screens/Store/Component/ReviewTextView.swift
+++ b/DakeAndDevileCorps/Screens/Store/Component/ReviewTextView.swift
@@ -12,6 +12,7 @@ final class ReviewTextView: UIView {
     private enum TextMode {
         case beforeWriting
         case write
+        case complete
         
         var placeholder: String? {
             switch self {
@@ -26,7 +27,7 @@ final class ReviewTextView: UIView {
             switch self {
             case .beforeWriting:
                 return .tertiaryLabel
-            case .write:
+            default:
                 return .black
             }
         }
@@ -56,9 +57,10 @@ final class ReviewTextView: UIView {
     }()
     private var textMode: TextMode? {
         willSet {
-            if let newValue = newValue {
-                applyTextViewConfiguration(with: newValue)
-            }
+            guard let newValue = newValue,
+                  newValue != .complete else { return }
+            
+            applyTextViewConfiguration(with: newValue)
         }
     }
 
@@ -96,10 +98,25 @@ final class ReviewTextView: UIView {
     
     private func configUI() {
         textMode = .beforeWriting
+        reviewTextView.delegate = self
     }
     
     private func applyTextViewConfiguration(with state: TextMode) {
-        reviewTextView.textColor = state.textColor
         reviewTextView.text = state.placeholder
+        reviewTextView.textColor = state.textColor
+    }
+}
+
+extension ReviewTextView: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        let isBeforeWriting = textMode == .beforeWriting
+        if isBeforeWriting {
+            textMode = .write
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        let isEmpty = textView.text.isEmpty
+        textMode = isEmpty ? .beforeWriting : .complete
     }
 }

--- a/DakeAndDevileCorps/Screens/Store/Component/ReviewTextView.swift
+++ b/DakeAndDevileCorps/Screens/Store/Component/ReviewTextView.swift
@@ -9,6 +9,29 @@ import UIKit
 
 final class ReviewTextView: UIView {
     
+    private enum TextMode {
+        case beforeWriting
+        case write
+        
+        var placeholder: String? {
+            switch self {
+            case .beforeWriting:
+                return "리뷰를 남겨주세요"
+            default:
+                return nil
+            }
+        }
+        
+        var textColor: UIColor {
+            switch self {
+            case .beforeWriting:
+                return .tertiaryLabel
+            case .write:
+                return .black
+            }
+        }
+    }
+    
     // MARK: - properties
     
     private let borderView: UIView = {
@@ -31,12 +54,20 @@ final class ReviewTextView: UIView {
         textView.font = .preferredFont(forTextStyle: .subheadline)
         return textView
     }()
+    private var textMode: TextMode? {
+        willSet {
+            if let newValue = newValue {
+                applyTextViewConfiguration(with: newValue)
+            }
+        }
+    }
 
     // MARK: - init
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         render()
+        configUI()
     }
     
     required init?(coder: NSCoder) {
@@ -63,4 +94,12 @@ final class ReviewTextView: UIView {
                                   padding: UIEdgeInsets(top: 16, left: 16, bottom: 12, right: 16))
     }
     
+    private func configUI() {
+        textMode = .beforeWriting
+    }
+    
+    private func applyTextViewConfiguration(with state: TextMode) {
+        reviewTextView.textColor = state.textColor
+        reviewTextView.text = state.placeholder
+    }
 }

--- a/DakeAndDevileCorps/Screens/Store/Component/ReviewTextView.swift
+++ b/DakeAndDevileCorps/Screens/Store/Component/ReviewTextView.swift
@@ -47,12 +47,12 @@ final class ReviewTextView: UIView {
         label.textColor = .secondaryLabel
         label.font = .preferredFont(forTextStyle: .caption2,
                                     compatibleWith: .init(legibilityWeight: .bold))
-        label.text = "0/300"
         return label
     }()
-    private let reviewTextView: UITextView = {
+    private lazy var reviewTextView: UITextView = {
         let textView = UITextView()
         textView.font = .preferredFont(forTextStyle: .subheadline)
+        textView.delegate = self
         return textView
     }()
     private var textMode: TextMode? {
@@ -63,6 +63,7 @@ final class ReviewTextView: UIView {
             applyTextViewConfiguration(with: newValue)
         }
     }
+    private let maxCount = 300
 
     // MARK: - init
     
@@ -97,13 +98,24 @@ final class ReviewTextView: UIView {
     }
     
     private func configUI() {
+        counterLabel.text = "0/\(maxCount)"
         textMode = .beforeWriting
-        reviewTextView.delegate = self
     }
     
     private func applyTextViewConfiguration(with state: TextMode) {
         reviewTextView.text = state.placeholder
         reviewTextView.textColor = state.textColor
+    }
+    
+    private func setCounter(count: Int) {
+        counterLabel.text = "\(count)/\(maxCount)"
+        checkMaxLength(textView: reviewTextView, maxLength: maxCount)
+    }
+    
+    private func checkMaxLength(textView: UITextView, maxLength: Int) {
+        if (textView.text?.count ?? 0 > maxLength) {
+            textView.deleteBackward()
+        }
     }
 }
 
@@ -118,5 +130,9 @@ extension ReviewTextView: UITextViewDelegate {
     func textViewDidEndEditing(_ textView: UITextView) {
         let isEmpty = textView.text.isEmpty
         textMode = isEmpty ? .beforeWriting : .complete
+    }
+    
+    func textViewDidChange(_ textView: UITextView) {
+        setCounter(count: textView.text?.count ?? 0)
     }
 }

--- a/DakeAndDevileCorps/Screens/Store/VC/WriteReviewViewController.swift
+++ b/DakeAndDevileCorps/Screens/Store/VC/WriteReviewViewController.swift
@@ -30,6 +30,13 @@ final class WriteReviewViewController: BaseViewController {
     
     var storeName: String = "알맹상점"
     
+    // MARK: - life cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        hidekeyboardWhenTappedAround()
+    }
+    
     override func render() {
         view.addSubview(reviewInputView)
         reviewInputView.constraint(top: view.safeAreaLayoutGuide.topAnchor,


### PR DESCRIPTION
## 🟣 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- close #62 

## 🟣 구현/변경 사항 및 이유

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
TextView를 우리 뷰에서 사용할 수 있도록 커스텀했습니다.

## 🟣 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

1. Auto 룰들을 no로 설정해뒀습니다.

2. TextView 내부 Text를 세는 기능을 추가했습니다.
3. TextView는 placeholder가 따로 없어서 placeholder와 비슷한 역할을 하도록 enum를 사용해서 구현했습니다. 
4. 300 이상이 되면 text가 안써지도록 구현했습니다.
   - 약간 커서가 버벅이는 듯한 느낌이 납니다. 해당 부분을 구현해두지 않으면 글자가 delete하면서 이상하게 나타나는 버그가 생깁니다. 따라서 차선책으로 버벅이지만 글자 버그가 나타나지 않도록 했습니다.
   - 참고 자료 : https://hello-developer.tistory.com/88

## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

![Simulator Screen Recording - iPhone 12 - 2022-07-29 at 18 15 56](https://user-images.githubusercontent.com/55099365/181727215-ed33dc86-46f5-422f-a6e0-3b6ef36a7a21.gif)

