### PR TITLE
[FIX] Deselect 부분 문제 수정

### DIFF
--- a/DakeAndDevileCorps/Global/UIComponent/CategoryView.swift
+++ b/DakeAndDevileCorps/Global/UIComponent/CategoryView.swift
@@ -70,6 +70,17 @@ final class CategoryView: UIView {
         categoryCollectionView.dataSource = self
         categoryCollectionView.register(CategoryCollectionViewCell.self, forCellWithReuseIdentifier: CategoryCollectionViewCell.className)
     }
+    
+    private func selectMapDelegateMethod(with isSelected: Bool,
+                                         collectionView: UICollectionView,
+                                         indexPath: IndexPath) {
+        guard entryPoint == .map else { return }
+        
+        isSelected ?
+        delegate?.collectionView(collectionView, didSelectItemAt: indexPath)
+        :
+        delegate?.collectionView?(collectionView, didDeselectItemAt: indexPath)
+    }
 }
 
 extension CategoryView: UICollectionViewDataSource {
@@ -93,13 +104,15 @@ extension CategoryView: UICollectionViewDelegate {
         let isSelectedAccordingToEntryPoint = (entryPoint == .map) ? isSelectedForMap : isSelected
         
         cell.applySelectedState(isSelectedAccordingToEntryPoint)
-        delegate?.collectionView(collectionView, didSelectItemAt: indexPath)
+        
+        selectMapDelegateMethod(with: isSelectedForMap,
+                                collectionView: collectionView,
+                                indexPath: indexPath)
     }
     
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         guard let cell = collectionView.cellForItem(at: indexPath) as? CategoryCollectionViewCell else { return }
         
         cell.applySelectedState(false)
-        delegate?.collectionView?(collectionView, didDeselectItemAt: indexPath)
     }
 }


### PR DESCRIPTION
## 🟣 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- close #64 

## 🟣 구현/변경 사항 및 이유

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
Deselect가 적당한 부분에서 불리도록 수정했습니다.

## 🟣 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 이미 눌린 셀에서 다시 눌릴 때 deselect 메소드가 불리도록 수정했습니다.
- 혹시 진짜 deselect된 걸 받아오고 싶으시다면 여기다가 delegate 메소드를 넣어주시면 됩니다!
```swift
func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
        guard let cell = collectionView.cellForItem(at: indexPath) as? CategoryCollectionViewCell else { return }
        
        cell.applySelectedState(false)
}
```

## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

