### PR TITLE
[FIX] 취급물품 음수뜨는 현상 수정 

### DIFF
--- a/DakeAndDevileCorps/Screens/Store/VC/StoreDetailViewController.swift
+++ b/DakeAndDevileCorps/Screens/Store/VC/StoreDetailViewController.swift
@@ -30,7 +30,8 @@ class StoreDetailViewController: BaseViewController {
     private var categoryHeader = CategoryView(entryPoint: .detail)
     private var itemInformationType: ItemInformationType = .productList
     private var store: Store?
-    var dataIndex: Int = 0
+    var dataIndex: Int = 4
+    var numberOfCategory: Int = 0
     weak var delegate: StoreDetailViewControllerDelegate?
     
     // MARK: - func
@@ -74,6 +75,7 @@ class StoreDetailViewController: BaseViewController {
         
         itemList.forEach({ item in
             if itemList.first(where: { $0.category == item.category }) == item {
+                numberOfCategory += 1
                 productList.append(.product(productName: item.category))
             }
             productList.append(.item(itemName: item.name))
@@ -266,6 +268,6 @@ extension StoreDetailViewController: StoreDetailSelectViewDelegate {
     
     func updateListCountOfButton(_ storeDetailSelectView: StoreDetailSelectView) {
         storeDetailSelectView.numberOfReviews = commentList.count
-        storeDetailSelectView.numberOfProducts = productList.count - categoryList.count
+        storeDetailSelectView.numberOfProducts = productList.count - numberOfCategory
     }
 }


### PR DESCRIPTION
## 🟣 관련 이슈
- 취급 물품의 개수를 띄워주는 로직에 문제가 있어 물품수가 음수로 뜨는 현상
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- close #110

## 🟣 구현/변경 사항 및 이유
- 기존에는 해당매장이 보유하고 있지 않은 category도 포함된 categoryList 전부를 count해서 빼줬기 때문에 음수가 떴다.
- 해당매장이 보유하고 있는 category 수를 count하여 빼주는 방식으로 변경
- 급하게 짠거라 추후 리팩토링 여지 있음
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🟣 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🟣 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

